### PR TITLE
Streamをreturnする

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -11,7 +11,7 @@ let espower = require("gulp-espower");
 let mocha = require("gulp-mocha");
 
 gulp.task("tsconfig", () => {
-    gulp
+    return gulp
         .src([
             "./lib/**/*.ts",
             "!./lib/**/*.d.ts",
@@ -29,7 +29,7 @@ gulp.task("tsc", shell.task([
 ]));
 
 gulp.task("tslint", () => {
-    gulp
+    return gulp
         .src([
             "./lib/**/*.ts",
             "./test/**/*.ts"
@@ -41,7 +41,7 @@ gulp.task("tslint", () => {
 });
 
 gulp.task("espower", () => {
-    gulp
+    return gulp
         .src([
             "./test/**/*.js"
         ])
@@ -50,7 +50,7 @@ gulp.task("espower", () => {
 });
 
 gulp.task("test", () => {
-    gulp
+    return gulp
         .src([
             "./lib/**/*.js",
             "!./lib/cli.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-espower": "1.0.0",
     "gulp-mocha": "2.1.3",
     "gulp-shell": "0.4.3",
-    "gulp-tsconfig-update": "1.0.5",
+    "gulp-tsconfig-update": "1.0.6",
     "gulp-tslint": "3.2.0",
     "load-grunt-tasks": "3.2.0",
     "power-assert": "1.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,17 +20,17 @@
     "files": [
         "./lib/cli.ts",
         "./lib/index.ts",
-        "./node_modules/commandpost/commandpost.d.ts",
-        "./node_modules/typescript/bin/lib.es6.d.ts",
         "./test/indexSpec.ts",
-        "./typings/bundle.d.ts",
         "./typings/empower/empower.d.ts",
-        "./typings/gulp/gulp.d.ts",
         "./typings/mocha/mocha.d.ts",
+        "./typings/gulp/gulp.d.ts",
         "./typings/node/node.d.ts",
         "./typings/orchestrator/orchestrator.d.ts",
-        "./typings/power-assert-formatter/power-assert-formatter.d.ts",
         "./typings/power-assert/power-assert.d.ts",
-        "./typings/q/Q.d.ts"
+        "./typings/power-assert-formatter/power-assert-formatter.d.ts",
+        "./typings/q/Q.d.ts",
+        "./typings/bundle.d.ts",
+        "./node_modules/commandpost/commandpost.d.ts",
+        "./node_modules/typescript/bin/lib.es6.d.ts"
     ]
 }


### PR DESCRIPTION
- gulp-tsconfig-updateを1.0.6にアップデート
- ↑で`files`をソートせずglobの順番に展開するようにした
- 全タスクをreturnして同期的に処理されることを保証
